### PR TITLE
[FIX] Added symfony/yaml as a composer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "description": "Import/Export core_config_data values in Magento 2",
   "require": {
     "php": "~5.5.0|~5.6.0|~7.0.0",
+    "symfony/yaml": "~2.0",
     "magento/module-config": "*",
     "magento/module-store": "*",
     "magento/framework": "*"


### PR DESCRIPTION
First, thank you for making this project open source!
Here is my very little contribution.

If you execute a composer install with --no-dev option and then execute config:data:import, you'll get a PHP fatal error because symfony/yaml dependency is missing.

``` bash
PHP Fatal error:  Uncaught Error: Class 'Symfony\Component\Yaml\Yaml' not found
```

It works fine in dev because phpunit package already includes symfony/yaml as a dependency.

This commit fixes the problem by explicitly adding symfony/yaml as a dependency in composer.json.

Thanks again.
