### PR TITLE
Objectmanager config now works in Compiled environment

### DIFF
--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -9,6 +9,7 @@ use Magento\Framework\App\ObjectManager\ConfigLoader;
 use Magento\Framework\App\State as AppState;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Registry;
+use Magento\Framework\App\Area;
 use Magento\Framework\App\Cache\Manager as CacheManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -92,7 +93,13 @@ abstract class AbstractCommand extends Command
         $this->output = $output;
 
         $this->appState->setAreaCode('adminhtml');
-        $this->objectManager->configure($this->configLoader->load('adminhtml'));
+        // Configure object manager to use Adminhtml area.
+        $this->objectManager->configure(
+            $this->objectManager
+                ->get('Magento\Framework\ObjectManager\ConfigLoaderInterface')
+                ->load(Area::AREA_ADMINHTML)
+        );
+        
         $this->registry->register('isSecureArea', true);
     }
 


### PR DESCRIPTION
This change is required to import configs after setup:di:compile has been run.
