### PR TITLE
[BUGFIX] Add support for scope codes -> convert to integer value

### DIFF
--- a/Model/Converter/ScopeConverter.php
+++ b/Model/Converter/ScopeConverter.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright © 2016 Christian Münch
+ * See LICENSE.md bundled with this module for license details.
+ */
+
+namespace Semaio\ConfigImportExport\Model\Converter;
+
+use Magento\Store\Model\StoreManagerInterface;
+
+class ScopeConverter implements ScopeConverterInterface
+{
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @param StoreManagerInterface $storeManager
+     */
+    public function __construct(StoreManagerInterface $storeManager)
+    {
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * Converts a string scope to integer scope id if needed
+     *
+     * @param string|int $scopeId
+     * @param $scope
+     * @return int
+     */
+    public function convert($scopeId, $scope)
+    {
+        if (is_numeric($scopeId)) {
+            return $scopeId;
+        }
+
+        if ($scope == 'stores') {
+            $store = $this->storeManager->getStore($scopeId);
+            if ($store->getId() > 0) {
+                return $store->getId();
+            }
+        }
+
+        if ($scope == 'websites') {
+            $website = $this->storeManager->getWebsite($scopeId);
+            if ($website->getId() > 0) {
+                return $website->getId();
+            }
+        }
+
+        return $scopeId;
+    }
+}

--- a/Model/Converter/ScopeConverterInterface.php
+++ b/Model/Converter/ScopeConverterInterface.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Copyright © 2016 Christian Münch
+ * See LICENSE.md bundled with this module for license details.
+ */
+
+namespace Semaio\ConfigImportExport\Model\Converter;
+
+interface ScopeConverterInterface
+
+{
+    /**
+     * Converts a string scope to integer scope id if needed
+     *
+     * @param string|int $scopeId
+     * @param $scope
+     * @return int
+     */
+    public function convert($scopeId, $scope);
+}

--- a/Model/Processor/ImportProcessor.php
+++ b/Model/Processor/ImportProcessor.php
@@ -6,6 +6,7 @@
 namespace Semaio\ConfigImportExport\Model\Processor;
 
 use Magento\Framework\App\Config\Storage\WriterInterface;
+use Semaio\ConfigImportExport\Model\Converter\ScopeConverterInterface;
 use Semaio\ConfigImportExport\Model\Validator\ScopeValidatorInterface;
 use Semaio\ConfigImportExport\Model\File\FinderInterface;
 use Semaio\ConfigImportExport\Model\File\Reader\ReaderInterface;
@@ -38,15 +39,23 @@ class ImportProcessor extends AbstractProcessor implements ImportProcessorInterf
     private $reader;
 
     /**
-     * @param WriterInterface         $configWriter
+     * @var ScopeConverterInterface
+     */
+    private $scopeConverter;
+
+    /**
+     * @param WriterInterface $configWriter
      * @param ScopeValidatorInterface $scopeValidator
+     * @param ScopeConverterInterface $scopeConverter
      */
     public function __construct(
         WriterInterface $configWriter,
-        ScopeValidatorInterface $scopeValidator
+        ScopeValidatorInterface $scopeValidator,
+        ScopeConverterInterface $scopeConverter
     ) {
         $this->configWriter = $configWriter;
         $this->scopeValidator = $scopeValidator;
+        $this->scopeConverter = $scopeConverter;
     }
 
     /**
@@ -70,7 +79,7 @@ class ImportProcessor extends AbstractProcessor implements ImportProcessorInterf
                         $configPath,
                         $scopeConfigValue['value'],
                         $scopeConfigValue['scope'],
-                        $scopeConfigValue['scope_id']
+                        $this->scopeConverter->convert($scopeConfigValue['scope_id'], $scopeConfigValue['scope'])
                     );
 
                     $this->getOutput()->writeln(sprintf('<comment>%s => %s</comment>', $configPath, $scopeConfigValue['value']));

--- a/Test/Unit/Model/Converter/ScopeConverterTest.php
+++ b/Test/Unit/Model/Converter/ScopeConverterTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Semaio\ConfigImportExport\Test\Unit\Model\Converter;
+
+
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Api\Data\WebsiteInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Semaio\ConfigImportExport\Model\Converter\ScopeConverter;
+
+class ScopeConverterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $storeManagerMock;
+
+    /**
+     * @var ScopeConverter
+     */
+    private $converter;
+
+    protected function setUp()
+    {
+        $this->storeManagerMock = $this->getMockBuilder(StoreManagerInterface::class)->getMock();
+
+        $this->converter = new ScopeConverter($this->storeManagerMock);
+    }
+
+    /**
+     * @test
+     * @dataProvider itShouldNotConvertNumericScopeIdsProvider
+     */
+    public function itShouldNotConvertNumericScopeIds($scopeId, $scope)
+    {
+        $this->storeManagerMock
+            ->expects($this->never())
+            ->method('getStore');
+
+        $this->storeManagerMock
+            ->expects($this->never())
+            ->method('getWebsite');
+
+        $this->assertEquals($scopeId, $this->converter->convert($scopeId, $scope));
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldNotConvertStoreCodeValues()
+    {
+        $storeCode = 'mystore';
+        $scope = 'stores';
+        $storeId = 2;
+
+        $storeStub = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $storeStub
+            ->expects($this->any())
+            ->method('getId')
+            ->willReturn($storeId);
+
+        $this->storeManagerMock
+            ->expects($this->once())
+            ->method('getStore')
+            ->with($storeCode)
+            ->willReturn($storeStub);
+
+        $this->assertEquals($storeId, $this->converter->convert($storeCode, $scope));
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldNotConvertWebsiteCodeValues()
+    {
+        $websiteCode = 'mywebsite';
+        $scope = 'websites';
+        $websiteId = 3;
+
+        $storeStub = $this->getMockBuilder(WebsiteInterface::class)->getMock();
+        $storeStub
+            ->expects($this->any())
+            ->method('getId')
+            ->willReturn($websiteId);
+
+        $this->storeManagerMock
+            ->expects($this->once())
+            ->method('getWebsite')
+            ->with($websiteCode)
+            ->willReturn($storeStub);
+
+        $this->assertEquals($websiteId, $this->converter->convert($websiteCode, $scope));
+    }
+
+    /**
+     * @return array
+     */
+    public function itShouldNotConvertNumericScopeIdsProvider()
+    {
+        return [
+            [1, 'default'],
+            [2, 'stores'],
+            [3, 'websites'],
+        ];
+    }
+}

--- a/Test/Unit/Model/Processor/ImportProcessorTest.php
+++ b/Test/Unit/Model/Processor/ImportProcessorTest.php
@@ -5,7 +5,11 @@
  */
 namespace Semaio\ConfigImportExport\Test\Unit\Model\Processor;
 
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Semaio\ConfigImportExport\Model\Converter\ScopeConverterInterface;
 use Semaio\ConfigImportExport\Model\Processor\ImportProcessor;
+use Semaio\ConfigImportExport\Model\Validator\ScopeValidatorInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Class ImportProcessorTest
@@ -15,19 +19,24 @@ use Semaio\ConfigImportExport\Model\Processor\ImportProcessor;
 class ImportProcessorTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \Symfony\Component\Console\Output\OutputInterface
+     * @var OutputInterface
      */
     private $outputMock;
 
     /**
-     * @var \Magento\Framework\App\Config\Storage\WriterInterface
+     * @var WriterInterface
      */
     private $configWriterMock;
 
     /**
-     * @var \Semaio\ConfigImportExport\Model\Validator\ScopeValidatorInterface
+     * @var ScopeValidatorInterface
      */
     private $scopeValidatorMock;
+
+    /**
+     * @var ScopeConverterInterface
+     */
+    private $scopeConverterMock;
 
     /**
      * Set up test class
@@ -35,9 +44,10 @@ class ImportProcessorTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->outputMock = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
-        $this->configWriterMock = $this->getMock('Magento\Framework\App\Config\Storage\WriterInterface');
-        $this->scopeValidatorMock = $this->getMock('Semaio\ConfigImportExport\Model\Validator\ScopeValidatorInterface');
+        $this->outputMock = $this->getMockBuilder(OutputInterface::class)->getMock();
+        $this->configWriterMock = $this->getMockBuilder(WriterInterface::class)->getMock();
+        $this->scopeValidatorMock = $this->getMockBuilder(ScopeValidatorInterface::class)->getMock();
+        $this->scopeConverterMock = $this->getMockBuilder(ScopeConverterInterface::class)->getMock();
     }
 
     /**
@@ -50,7 +60,7 @@ class ImportProcessorTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException('InvalidArgumentException');
 
-        $processor = new ImportProcessor($this->configWriterMock, $this->scopeValidatorMock);
+        $processor = new ImportProcessor($this->configWriterMock, $this->scopeValidatorMock, $this->scopeConverterMock);
         $processor->setFinder($finderMock);
         $processor->process();
     }
@@ -77,7 +87,7 @@ class ImportProcessorTest extends \PHPUnit_Framework_TestCase
         $this->scopeValidatorMock->expects($this->once())->method('validate')->willReturn(false);
         $this->configWriterMock->expects($this->never())->method('save');
 
-        $processor = new ImportProcessor($this->configWriterMock, $this->scopeValidatorMock);
+        $processor = new ImportProcessor($this->configWriterMock, $this->scopeValidatorMock, $this->scopeConverterMock);
         $processor->setFormat('yaml');
         $processor->setOutput($this->outputMock);
         $processor->setFinder($finderMock);
@@ -108,7 +118,7 @@ class ImportProcessorTest extends \PHPUnit_Framework_TestCase
         $this->scopeValidatorMock->expects($this->once())->method('validate')->willReturn(true);
         $this->configWriterMock->expects($this->once())->method('save');
 
-        $processor = new ImportProcessor($this->configWriterMock, $this->scopeValidatorMock);
+        $processor = new ImportProcessor($this->configWriterMock, $this->scopeValidatorMock, $this->scopeConverterMock);
         $processor->setOutput($this->outputMock);
         $processor->setFinder($finderMock);
         $processor->setReader($readerMock);

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -10,6 +10,7 @@
     <preference for="Semaio\ConfigImportExport\Model\Processor\ImportProcessorInterface" type="Semaio\ConfigImportExport\Model\Processor\ImportProcessor"/>
     <preference for="Semaio\ConfigImportExport\Model\Validator\ScopeValidatorInterface" type="Semaio\ConfigImportExport\Model\Validator\ScopeValidator"/>
     <preference for="Semaio\ConfigImportExport\Model\File\FinderInterface" type="Semaio\ConfigImportExport\Model\File\Finder"/>
+    <preference for="Semaio\ConfigImportExport\Model\Converter\ScopeConverterInterface" type="Semaio\ConfigImportExport\Model\Converter\ScopeConverter" />
 
     <type name="Magento\Framework\Console\CommandList">
         <arguments>


### PR DESCRIPTION
Currently the scope id can be a string. The validator checks if the value is correct. If the value is correct it must be converted from a code (string) to the id (integer).
This is not done at the moment.
My PR adds a new converter which converts the already validated values.
