### PR TITLE
Stabilize parsing of YAML files, fixes #10

### DIFF
--- a/Model/File/Reader/ReaderInterface.php
+++ b/Model/File/Reader/ReaderInterface.php
@@ -14,7 +14,7 @@ interface ReaderInterface
 {
     /**
      * @param string $fileName
-     * @return array
+     * @return mixed
      */
     public function parse($fileName);
 }

--- a/Model/File/Reader/YamlReader.php
+++ b/Model/File/Reader/YamlReader.php
@@ -16,12 +16,14 @@ class YamlReader extends AbstractReader
 {
     /**
      * @param string $fileName
-     * @return array
+     * @return mixed
      */
     public function parse($fileName)
     {
         $content = SymfonyYaml::parse($fileName);
 
-        return $this->normalize($content);
+        return is_array($content)
+            ? $this->normalize($content)
+            : $content;
     }
 }

--- a/Model/Processor/ImportProcessor.php
+++ b/Model/Processor/ImportProcessor.php
@@ -71,7 +71,7 @@ class ImportProcessor extends AbstractProcessor implements ImportProcessorInterf
 
         foreach ($files as $file) {
             $valuesSet = 0;
-            $configurations = $this->reader->parse($file);
+            $configurations = $this->getConfigurationsFromFile($file);
             foreach ($configurations as $configPath => $configValues) {
                 $scopeConfigValues = $this->transformConfigToScopeConfig($configPath, $configValues);
                 foreach ($scopeConfigValues as $scopeConfigValue) {
@@ -89,6 +89,22 @@ class ImportProcessor extends AbstractProcessor implements ImportProcessorInterf
 
             $this->getOutput()->writeln(sprintf('<info>Processed: %s with %s value(s).</info>', $file, $valuesSet));
         }
+    }
+
+    /**
+     * @param string $file
+     * @return array
+     */
+    private function getConfigurationsFromFile($file)
+    {
+        $configurations = $this->reader->parse($file);
+        if (!is_array($configurations)) {
+            $this->getOutput()->writeln(
+                sprintf("<error>Skipped: '%s' (not an array: %s).</error>", $file, var_export($configurations, true))
+            );
+            $configurations = [];
+        }
+        return $configurations;
     }
 
     /**


### PR DESCRIPTION
The YAML parser actually returns mixed results but previous non-array cases could not be handled.

Additionally if a file is being skipped more information is provided.
