### PR TITLE
deal with configuration having more than 3 parts in path

### DIFF
--- a/Model/File/Writer/AbstractWriter.php
+++ b/Model/File/Writer/AbstractWriter.php
@@ -93,20 +93,8 @@ abstract class AbstractWriter implements WriterInterface
     {
         $return = array();
         foreach ($exportData as $row) {
-            $pathDetails = explode('/', $row['path']);
-            if (!isset($return[$pathDetails[0]])) {
-                $return[$pathDetails[0]] = array();
-            }
-            if (!isset($return[$pathDetails[0]][$pathDetails[1]])) {
-                $return[$pathDetails[0]][$pathDetails[1]] = array();
-            }
-            if (!isset($return[$pathDetails[0]][$pathDetails[1]][$pathDetails[2]])) {
-                $return[$pathDetails[0]][$pathDetails[1]][$pathDetails[2]] = array();
-            }
-            if (!isset($return[$pathDetails[0]][$pathDetails[1]][$pathDetails[2]][$row['scope']])) {
-                $return[$pathDetails[0]][$pathDetails[1]][$pathDetails[2]][$row['scope']] = array();
-            }
-            $return[$pathDetails[0]][$pathDetails[1]][$pathDetails[2]][$row['scope']][$row['scope_id']] = $row['value'];
+            list($firstPart, $secondPart, $thirdPart) = explode('/', $row['path'], 3);
+            $return[$firstPart][$secondPart][$thirdPart][$row['scope']][$row['scope_id']] = $row['value'];
         }
 
         return $return;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR - thank you!

- [x] Pull request is based against develop branch
- [x] README.md reflects changes (if applicable)
- [x] New files contain a license header

### Issue

This PR fixes issue #15  .

### Proposed changes

Due to the fact that configuration path can have more than 3 parts (separated by /), in the abstract writer we get the first 2 parts normally and use the rest as the third part. E.g:

Suppose we have this configuration in database:

```
system/full_page_cache/varnish/access_list => localhost
system/full_page_cache/varnish/backend_host => localhost
system/full_page_cache/varnish/backend_port => 8080
```

Before the PR, this is the exported yaml configuration

```yaml
system:
  full_page_cache:
    varnish:
      default:
        - '8080'
```

After PR

```yaml
system:
  full_page_cache:
    varnish/access_list:
      default:
        - localhost
    varnish/backend_host:
      default:
        - localhost
    varnish/backend_port:
      default:
        - '8080'
```

 There's no change to the reader though as the configuration is parsed correctly either way
