### PR TITLE
Magento 2.2 and PHP 7.1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ php bin/magento module:enable Semaio_ConfigImportExport
 
 ## Facts
 
-Version: 2.2.2
+* Version: 3.0.0
+* Magento Support: >= 2.2
+* PHP Versions: 7.0 + 7.1
 
 ## Functionality
 

--- a/Test/Unit/Model/Converter/ScopeConverterTest.php
+++ b/Test/Unit/Model/Converter/ScopeConverterTest.php
@@ -3,6 +3,7 @@
  * Copyright © 2016 Rouven Alexander Rieker
  * See LICENSE.md bundled with this module for license details.
  */
+
 namespace Semaio\ConfigImportExport\Test\Unit\Model\Converter;
 
 use Magento\Store\Api\Data\StoreInterface;
@@ -15,10 +16,10 @@ use Semaio\ConfigImportExport\Model\Converter\ScopeConverter;
  *
  * @package Semaio\ConfigImportExport\Test\Unit\Model\Converter
  */
-class ScopeConverterTest extends \PHPUnit_Framework_TestCase
+class ScopeConverterTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var StoreManagerInterface
      */
     private $storeManagerMock;
 
@@ -70,9 +71,13 @@ class ScopeConverterTest extends \PHPUnit_Framework_TestCase
 
         $this->storeManagerMock
             ->expects($this->once())
-            ->method('getStore')
-            ->with($storeCode)
-            ->willReturn($storeStub);
+            ->method('getStores')
+            ->with($this->equalTo(true), $this->equalTo(true))
+            ->willReturn(
+                [
+                    $storeCode => $storeStub,
+                ]
+            );
 
         $this->assertEquals($storeId, $this->converter->convert($storeCode, $scope));
     }
@@ -94,9 +99,13 @@ class ScopeConverterTest extends \PHPUnit_Framework_TestCase
 
         $this->storeManagerMock
             ->expects($this->once())
-            ->method('getWebsite')
-            ->with($websiteCode)
-            ->willReturn($storeStub);
+            ->method('getWebsites')
+            ->with($this->equalTo(true), $this->equalTo(true))
+            ->willReturn(
+                [
+                    $websiteCode => $storeStub,
+                ]
+            );
 
         $this->assertEquals($websiteId, $this->converter->convert($websiteCode, $scope));
     }

--- a/Test/Unit/Model/File/FinderTest.php
+++ b/Test/Unit/Model/File/FinderTest.php
@@ -12,7 +12,7 @@ use Semaio\ConfigImportExport\Model\File\Finder;
  *
  * @package Semaio\ConfigImportExport\Test\Unit\Model\File
  */
-class FinderTest extends \PHPUnit_Framework_TestCase
+class FinderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Finder
@@ -56,7 +56,7 @@ class FinderTest extends \PHPUnit_Framework_TestCase
         $this->finder->setFolder($folder);
         $this->finder->setEnvironment('dev');
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $this->finder->find();
     }
 
@@ -71,7 +71,7 @@ class FinderTest extends \PHPUnit_Framework_TestCase
         $this->finder->setFolder($folder);
         $this->finder->setEnvironment('dev2');
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $this->finder->find();
     }
 
@@ -80,7 +80,7 @@ class FinderTest extends \PHPUnit_Framework_TestCase
      */
     public function setEnvironment()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $folder = __DIR__ . DIRECTORY_SEPARATOR . 'Finder' . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'store' . DIRECTORY_SEPARATOR;
         $this->finder->setFolder($folder);
         $this->finder->setEnvironment('abc');
@@ -91,7 +91,7 @@ class FinderTest extends \PHPUnit_Framework_TestCase
      */
     public function setFolder()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $folder = __DIR__ . DIRECTORY_SEPARATOR . 'Finder' . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'test';
         $this->finder->setFolder($folder);
     }

--- a/Test/Unit/Model/File/Reader/JsonReaderTest.php
+++ b/Test/Unit/Model/File/Reader/JsonReaderTest.php
@@ -12,7 +12,7 @@ use Semaio\ConfigImportExport\Model\File\Reader\JsonReader;
  *
  * @package Semaio\ConfigImportExport\Test\Unit\Model\File\Reader
  */
-class JsonReaderTest extends \PHPUnit_Framework_TestCase
+class JsonReaderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var JsonReader
@@ -48,7 +48,7 @@ class JsonReaderTest extends \PHPUnit_Framework_TestCase
     {
         $baseDir = __DIR__ . DIRECTORY_SEPARATOR . 'JsonReaderTest' . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR;
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         $this->reader->parse($baseDir . 'fx-test-invalid.json');
     }

--- a/Test/Unit/Model/File/Reader/YamlReaderTest.php
+++ b/Test/Unit/Model/File/Reader/YamlReaderTest.php
@@ -12,7 +12,7 @@ use Semaio\ConfigImportExport\Model\File\Reader\YamlReader;
  *
  * @package Semaio\ConfigImportExport\Test\Unit\Model\File\Reader
  */
-class YamlReaderTest extends \PHPUnit_Framework_TestCase
+class YamlReaderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var YamlReader

--- a/Test/Unit/Model/Processor/ImportProcessorTest.php
+++ b/Test/Unit/Model/Processor/ImportProcessorTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @package Semaio\ConfigImportExport\Test\Unit\Model\Processor
  */
-class ImportProcessorTest extends \PHPUnit_Framework_TestCase
+class ImportProcessorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var OutputInterface
@@ -55,10 +55,15 @@ class ImportProcessorTest extends \PHPUnit_Framework_TestCase
      */
     public function processWithoutFiles()
     {
-        $finderMock = $this->getMock('Semaio\ConfigImportExport\Model\File\Finder', ['find']);
-        $finderMock->expects($this->once())->method('find')->willReturn([]);
+        $finderMock = $this->getMockBuilder('Semaio\ConfigImportExport\Model\File\Finder')
+            ->setMethods(['find'])
+            ->getMock();
+        $finderMock
+            ->expects($this->once())
+            ->method('find')
+            ->willReturn([]);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         $processor = new ImportProcessor($this->configWriterMock, $this->scopeValidatorMock, $this->scopeConverterMock);
         $processor->setFinder($finderMock);
@@ -70,7 +75,9 @@ class ImportProcessorTest extends \PHPUnit_Framework_TestCase
      */
     public function processWithInvalidScopeData()
     {
-        $finderMock = $this->getMock('Semaio\ConfigImportExport\Model\File\Finder', ['find']);
+        $finderMock = $this->getMockBuilder('Semaio\ConfigImportExport\Model\File\Finder')
+            ->setMethods(['find'])
+            ->getMock();
         $finderMock->expects($this->once())->method('find')->willReturn(['abc.yaml']);
 
         $parseResult = [
@@ -81,7 +88,9 @@ class ImportProcessorTest extends \PHPUnit_Framework_TestCase
             ]
         ];
 
-        $readerMock = $this->getMock('Semaio\ConfigImportExport\Model\File\Reader\YamlReader', ['parse']);
+        $readerMock = $this->getMockBuilder('Semaio\ConfigImportExport\Model\File\Reader\YamlReader')
+            ->setMethods(['parse'])
+            ->getMock();
         $readerMock->expects($this->once())->method('parse')->willReturn($parseResult);
 
         $this->scopeValidatorMock->expects($this->once())->method('validate')->willReturn(false);
@@ -101,7 +110,9 @@ class ImportProcessorTest extends \PHPUnit_Framework_TestCase
      */
     public function process()
     {
-        $finderMock = $this->getMock('Semaio\ConfigImportExport\Model\File\Finder', ['find']);
+        $finderMock = $this->getMockBuilder('Semaio\ConfigImportExport\Model\File\Finder')
+            ->setMethods(['find'])
+            ->getMock();
         $finderMock->expects($this->once())->method('find')->willReturn(['abc.yaml']);
 
         $parseResult = [
@@ -112,7 +123,9 @@ class ImportProcessorTest extends \PHPUnit_Framework_TestCase
             ]
         ];
 
-        $readerMock = $this->getMock('Semaio\ConfigImportExport\Model\File\Reader\YamlReader', ['parse']);
+        $readerMock = $this->getMockBuilder('Semaio\ConfigImportExport\Model\File\Reader\YamlReader')
+            ->setMethods(['parse'])
+            ->getMock();
         $readerMock->expects($this->once())->method('parse')->willReturn($parseResult);
 
         $this->scopeValidatorMock->expects($this->once())->method('validate')->willReturn(true);

--- a/Test/Unit/Model/Validator/ScopeValidatorTest.php
+++ b/Test/Unit/Model/Validator/ScopeValidatorTest.php
@@ -14,7 +14,7 @@ use Semaio\ConfigImportExport\Model\Validator\ScopeValidator;
  *
  * @package Semaio\ConfigImportExport\Test\Unit\Model\Validator
  */
-class ScopeValidatorTest extends \PHPUnit_Framework_TestCase
+class ScopeValidatorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var ScopeValidator
@@ -38,7 +38,8 @@ class ScopeValidatorTest extends \PHPUnit_Framework_TestCase
             ->setMethods(['getCode'])
             ->getMockForAbstractClass();
 
-        $storeManagerMock = $this->getMock('Magento\Store\Model\StoreManagerInterface');
+        $storeManagerMock = $this->getMockBuilder('Magento\Store\Model\StoreManagerInterface')
+            ->getMock();
         $storeManagerMock->expects($this->any())->method('getWebsites')->willReturn([1 => $this->mockWebsiteOne]);
         $storeManagerMock->expects($this->any())->method('getStores')->willReturn([2 => 'ABC']);
 

--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,14 @@
   "name": "semaio/magento2-configimportexport",
   "description": "Import/Export core_config_data values in Magento 2",
   "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0",
+    "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
     "symfony/yaml": "~2.0",
-    "magento/module-config": "*",
-    "magento/module-store": "*",
-    "magento/framework": "*"
+    "magento/module-config": "~101.0.0",
+    "magento/module-store": "~100.2.0",
+    "magento/framework": "~101.0.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "~6.2.0"
   },
   "type": "magento2-module",
   "license": "OSL-3.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.2/phpunit.xsd"
+         colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="false">
+    <testsuite name="Unit Tests">
+        <directory suffix="Test.php">./Test/Unit</directory>
+    </testsuite>
+    <php>
+        <ini name="date.timezone" value="Europe/Berlin"/>
+        <ini name="xdebug.max_nesting_level" value="200"/>
+    </php>
+</phpunit>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR - thank you!

- [x] Pull request is based against develop branch
- [x] README.md reflects changes (if applicable)
- [x] New files contain a license header

### Issue

This PR fixes issue #19 .

### Proposed changes

I added the Magento 2.2 and PHP 7.1 compatibility including fixed PhpUnit tests for PhpUnit 6.2.

**ATTENTION:**
As these changes contain BC breaks (due to changed composer requirements), I highly recommend releasing this PR in/as next version 3.0.0
