### PR TITLE
YamlReader: get file content before parsing

### DIFF
--- a/Model/File/Reader/YamlReader.php
+++ b/Model/File/Reader/YamlReader.php
@@ -20,7 +20,7 @@ class YamlReader extends AbstractReader
      */
     public function parse($fileName)
     {
-        $content = SymfonyYaml::parse($fileName);
+        $content = SymfonyYaml::parse(file_get_contents($fileName));
 
         return is_array($content)
             ? $this->normalize($content)

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "semaio/magento2-configimportexport",
   "description": "Import/Export core_config_data values in Magento 2",
   "require": {
-    "symfony/yaml": "~2.0|~3.0",
+    "symfony/yaml": "~2.0|~3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~6.2.0"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "semaio/magento2-configimportexport",
   "description": "Import/Export core_config_data values in Magento 2",
   "require": {
-    "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
+    "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
     "symfony/yaml": "~2.0|~3.0",
     "magento/module-config": "~101.0.0",
     "magento/module-store": "~100.2.0",

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,7 @@
   "name": "semaio/magento2-configimportexport",
   "description": "Import/Export core_config_data values in Magento 2",
   "require": {
-    "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
     "symfony/yaml": "~2.0|~3.0",
-    "magento/module-config": "~102.0.0",
-    "magento/module-store": "~101.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~6.2.0"

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,8 @@
   "require": {
     "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
     "symfony/yaml": "~2.0|~3.0",
-    "magento/module-config": "~101.0.0",
-    "magento/module-store": "~100.2.0",
-    "magento/framework": "~101.0.0"
+    "magento/module-config": "~101.0.0|~102.0.0",
+    "magento/module-store": "~100.2.0|~102.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~6.2.0"

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
   "require": {
     "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
     "symfony/yaml": "~2.0|~3.0",
-    "magento/module-config": "~101.0.0|~102.0.0",
-    "magento/module-store": "~100.2.0|~101.0.0"
+    "magento/module-config": "~102.0.0",
+    "magento/module-store": "~101.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~6.2.0"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
     "symfony/yaml": "~2.0|~3.0",
     "magento/module-config": "~101.0.0|~102.0.0",
-    "magento/module-store": "~100.2.0|~102.0.0"
+    "magento/module-store": "~100.2.0|~101.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~6.2.0"


### PR DESCRIPTION
With Symfony Yaml >= 3.0 the option to pass a filename was removed. 
The commit 6c959b8c56a9e027e2f3727cc9719681e1fe2f8e introduces the compatibilty with >=3.0.

To support 2.0 and 3.0 of Symfony Yaml we need get the file contents in the YamlReader.

Also see:
Yaml.php @ v2.8 https://github.com/symfony/yaml/blob/2.8/Yaml.php#L58
Yaml.php @ v3.3 https://github.com/symfony/yaml/blob/3.3/Yaml.php#L52

The ``file_get_contents`` is no longer there.

Please make sure these boxes are checked before submitting your PR - thank you!

- [ ] Pull request is based against develop branch
- [ ] README.md reflects changes (if applicable)
- [ ] New files contain a license header

### Issue

This PR fixes issue # .

### Proposed changes

... 
