### PR TITLE
Update YamlReader to use new parseFile function from symfony/yaml

### DIFF
--- a/Model/File/Reader/YamlReader.php
+++ b/Model/File/Reader/YamlReader.php
@@ -20,7 +20,7 @@ class YamlReader extends AbstractReader
      */
     public function parse($fileName)
     {
-        $content = SymfonyYaml::parse($fileName);
+        $content = SymfonyYaml::parseFile($fileName);
 
         return is_array($content)
             ? $this->normalize($content)

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Import/Export core_config_data values in Magento 2",
   "require": {
     "php": "~7.0.0 || ~7.1.0 || ~7.2.0",
-    "symfony/yaml": "^3.1 || ^4.0",
+    "symfony/yaml": "^3.4 || ^4.0",
     "magento/module-config": "*",
     "magento/module-store": "*",
     "magento/framework": "~100.1 || ~101.0 || ~102.0"


### PR DESCRIPTION
The recent symfony/yaml versions introduced a parseFile function to load
and parse yaml from file system. Require symfony/yaml in 3.4+ / 4.0+ to
ensure new function is present.

- [x] Pull request is based against develop branch
- [x] README.md reflects changes (if applicable)
- [x] New files contain a license header

### Issue

This PR fixes issue #32.

### Proposed changes

Require symfony/yaml in version >=3.4 to ensure `Yaml::parseFile()` is available.
