### PR TITLE
Add --recursive option for config Import

### DIFF
--- a/Command/ImportCommand.php
+++ b/Command/ImportCommand.php
@@ -117,6 +117,13 @@ class ImportCommand extends AbstractCommand
             'Do not clear cache after config data import.'
         );
 
+        $this->addOption(
+            'recursive',
+            'r',
+            InputOption::VALUE_NONE,
+            'Recursively go over subdirectories and import configs.'
+        );
+
         parent::configure();
     }
 
@@ -147,6 +154,7 @@ class ImportCommand extends AbstractCommand
         $folder = $input->getArgument('folder');
         $baseFolder = $input->getOption('base');
         $environment = $input->getArgument('environment');
+        $depth = ($input->getOption('recursive') === false) ? '0' : '>= 1';
 
         // Configure the finder
         $finder = $this->finder;
@@ -154,6 +162,7 @@ class ImportCommand extends AbstractCommand
         $finder->setBaseFolder($baseFolder);
         $finder->setEnvironment($environment);
         $finder->setFormat($format);
+        $finder->setDepth($depth);
 
         // Process the import
         $this->importProcessor->setFormat($format);

--- a/Model/File/Finder.php
+++ b/Model/File/Finder.php
@@ -36,11 +36,16 @@ class Finder implements FinderInterface
     private $environment;
 
     /**
+     * @var string
+     */
+    private $depth;
+
+    /**
      * @return array
      */
     public function find()
     {
-        $baseFiles = $this->search($this->folder . DIRECTORY_SEPARATOR . $this->baseFolder . DIRECTORY_SEPARATOR);
+        $baseFiles = $this->search($this->folder . DIRECTORY_SEPARATOR . $this->baseFolder . DIRECTORY_SEPARATOR, $this->depth);
         if (0 === count($baseFiles)) {
             throw new \InvalidArgumentException('No base files found for format: *.' . $this->format);
         }
@@ -49,7 +54,7 @@ class Finder implements FinderInterface
         $envFiles = [];
         foreach ($this->environment as $envPath) {
             $fullEnvPath .= $envPath . DIRECTORY_SEPARATOR;
-            $find = $this->search($this->folder . DIRECTORY_SEPARATOR . $fullEnvPath, '0');
+            $find = $this->search($this->folder . DIRECTORY_SEPARATOR . $fullEnvPath, $this->depth);
             $envFiles = array_merge($envFiles, $find);
         }
 
@@ -129,5 +134,13 @@ class Finder implements FinderInterface
         }
 
         return $files;
+    }
+
+    /**
+     * @param string $depth
+     */
+    public function setDepth($depth): void
+    {
+        $this->depth = $depth;
     }
 }

--- a/Model/File/FinderInterface.php
+++ b/Model/File/FinderInterface.php
@@ -37,4 +37,9 @@ interface FinderInterface
      * @param mixed $format
      */
     public function setFormat($format);
+
+    /**
+     * @param mixed $depth
+     */
+    public function setDepth($depth);
 }

--- a/docs/config-import.md
+++ b/docs/config-import.md
@@ -18,6 +18,7 @@ $ php bin/magento config:data:import --help
   --base                Base folder name (default: "base")
   --format (-m)         Format: yaml, json (Default: yaml) (default: "yaml")
   --no-cache            Do not clear cache after config data import.
+  --recursive (-r)      Recursively go over subdirectories and import configs.
 ```
 
 :exclamation: Only use the `no-cache` option if you clear the cache afterwards, e.g. in a deployment process. Otherwise the changes will have no effect.
@@ -49,9 +50,9 @@ magento_root
 └── pub
 ```
 
-To import my ([@therouv](https://github.com/therouv)) specific Magento configuration settings, 
+To import my ([@therouv](https://github.com/therouv)) specific Magento configuration settings,
 I would run the following command in the "magento_root" directory:
 
-```bash 
+```bash
 php bin/magento config:data:import config/store dev/therouv
 ```


### PR DESCRIPTION
### Issue

.

### Proposed changes

I want to support this config files structure
```
magento_root
...
├── config
│   └── store
│       ├── base
│       │       ├── vendor1
│       │       │   ├── geoip.yaml
│       │       │   └── storepickup.yaml
│       │       └── vendor2
│       │           └── general.yaml
│       └── staging
│               ├── vendor1
│               │   └── recaptcha.yaml
│               └── vendor2
│                   └── general.yaml
...
```

For this purpose I added -r option for Import command. It allows to find config files recursively and import them.

So I use this command `bin/magento config:data:import config staging -r` to import my configs.