### PR TITLE
Update regex in env var resolver

### DIFF
--- a/Model/Resolver/EnvironmentVariableResolver.php
+++ b/Model/Resolver/EnvironmentVariableResolver.php
@@ -28,7 +28,7 @@ class EnvironmentVariableResolver
     {
         $this->value = $value;
         return preg_replace_callback(
-            '/\%env\(([^:\%\%]+?)\)\%/',
+            '/\%env\((?!PHP_|HTTP_|SERVER_|SCRIPT_|QUERY_|DOCUMENT_)([A-Z\_]{3,})\)\%/',
             function ($matches) {
                 $resolvedValue = getenv($matches[1]);
                 if ($resolvedValue === false) {

--- a/Test/Unit/Model/Resolver/EnvironmentVariableResolverTest.php
+++ b/Test/Unit/Model/Resolver/EnvironmentVariableResolverTest.php
@@ -41,6 +41,15 @@ class EnvironmentVariableResolverTest extends TestCase
     {
         $this->assertEquals($this->environmentVariableResolver->resolveValue('test_without_env_var'), 'test_without_env_var');
 
+        $this->assertEquals($this->environmentVariableResolver->resolveValue('%env(PA)%'), '%env(PA)%');
+        $this->assertEquals($this->environmentVariableResolver->resolveValue('%env(lowercase)%'), '%env(lowercase)%');
+        $this->assertEquals($this->environmentVariableResolver->resolveValue('%env(SCRIPT_SOMETHING)%'), '%env(SCRIPT_SOMETHING)%');
+        $this->assertEquals($this->environmentVariableResolver->resolveValue('%env(PHP_SOMETHING)%'), '%env(PHP_SOMETHING)%');
+        $this->assertEquals($this->environmentVariableResolver->resolveValue('%env(HTTP_SOMETHING)%'), '%env(HTTP_SOMETHING)%');
+        $this->assertEquals($this->environmentVariableResolver->resolveValue('%env(SERVER_SOMETHING)%'), '%env(SERVER_SOMETHING)%');
+        $this->assertEquals($this->environmentVariableResolver->resolveValue('%env(QUERY_SOMETHING)%'), '%env(QUERY_SOMETHING)%');
+        $this->assertEquals($this->environmentVariableResolver->resolveValue('%env(DOCUMENT_SOMETHING)%'), '%env(DOCUMENT_SOMETHING)%');
+
         $this->assertEquals($this->environmentVariableResolver->resolveValue('%env(HOSTNAME)%'), 'testvalue1');
         $this->assertEquals($this->environmentVariableResolver->resolveValue('https://%env(SUBDOMAIN)%.example.com'), 'https://testvalue2.example.com');
         $this->assertEquals($this->environmentVariableResolver->resolveValue('%env(CONCAT_THIS)%%env(WITH_THIS)%'), 'testvalue3testvalue4');


### PR DESCRIPTION
- Only allow uppercase characters and underscore
- Min 3 characters
- Disallow env vars that start with PHP_, HTTP_, SERVER_, SCRIPT_, QUERY_ and DOCUMENT_

Thanks @damienwebdev @sprankhub