### PR TITLE
Add interactive env var support

### DIFF
--- a/Command/ImportCommand.php
+++ b/Command/ImportCommand.php
@@ -92,7 +92,7 @@ class ImportCommand extends AbstractCommand
 
         $this->addOption(
             'base',
-            null,
+            'b',
             InputOption::VALUE_OPTIONAL,
             'Base folder name',
             'base'
@@ -118,6 +118,14 @@ class ImportCommand extends AbstractCommand
             'r',
             InputOption::VALUE_NONE,
             'Recursively go over subdirectories and import configs.'
+        );
+
+        $this->addOption(
+            'prompt-missing-env-vars',
+            'p',
+            InputOption::VALUE_OPTIONAL,
+            'Prompt for missing env vars input.',
+            true
         );
 
         parent::configure();
@@ -164,7 +172,9 @@ class ImportCommand extends AbstractCommand
         $this->importProcessor->setFormat($format);
         $this->importProcessor->setReader($reader);
         $this->importProcessor->setFinder($finder);
+        $this->importProcessor->setInput($input);
         $this->importProcessor->setOutput($output);
+        $this->importProcessor->setQuestionHelper($this->getHelper('question'));
         $this->importProcessor->process();
 
         // Clear the cache after import

--- a/Model/Processor/AbstractProcessor.php
+++ b/Model/Processor/AbstractProcessor.php
@@ -13,9 +13,19 @@ use Symfony\Component\Console\Output\OutputInterface;
 abstract class AbstractProcessor implements AbstractProcessorInterface
 {
     /**
+     * @var InputInterface
+     */
+    private $input;
+
+    /**
      * @var OutputInterface
      */
     private $output;
+    
+    /**
+     * @var QuestionHelper
+     */
+    private $questionHelper;
 
     /**
      * @var string

--- a/Model/Processor/AbstractProcessor.php
+++ b/Model/Processor/AbstractProcessor.php
@@ -6,6 +6,8 @@
 
 namespace Semaio\ConfigImportExport\Model\Processor;
 
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class AbstractProcessor implements AbstractProcessorInterface
@@ -34,6 +36,38 @@ abstract class AbstractProcessor implements AbstractProcessorInterface
     public function getOutput()
     {
         return $this->output;
+    }
+
+    /**
+     * @param InputInterface $input
+     */
+    public function setInput(InputInterface $input)
+    {
+        $this->input = $input;
+    }
+
+    /**
+     * @return InputInterface
+     */
+    public function getInput()
+    {
+        return $this->input;
+    }
+
+    /**
+     * @param QuestionHelper $questionHelper
+     */
+    public function setQuestionHelper(QuestionHelper $questionHelper)
+    {
+        $this->questionHelper = $questionHelper;
+    }
+
+    /**
+     * @return QuestionHelper
+     */
+    public function getQuestionHelper()
+    {
+        return $this->questionHelper;
     }
 
     /**

--- a/docs/config-import.md
+++ b/docs/config-import.md
@@ -11,14 +11,15 @@ $ php bin/magento config:data:import --help
   config:data:import [--base[="..."]] [-m|--format[="..."]] folder environment
 
  Arguments:
-  folder                Import folder name
-  environment           Environment name. SubEnvs separated by slash e.g.: development/osx/developer01
+  folder                           Import folder name
+  environment                      Environment name. SubEnvs separated by slash e.g.: development/osx/developer01
 
  Options:
-  --base                Base folder name (default: "base")
-  --format (-m)         Format: yaml, json (Default: yaml) (default: "yaml")
-  --no-cache            Do not clear cache after config data import.
-  --recursive (-r)      Recursively go over subdirectories and import configs.
+  --base (-b)                      Base folder name (default: "base")
+  --format (-m)                    Format: yaml, json (Default: yaml)
+  --no-cache                       Do not clear cache after config data import.
+  --recursive (-r)                 Recursively go over subdirectories and import configs.
+  --prompt-missing-env-vars (-p)   Prompt in interactive mode when environment variables are found but not configured (Default: true)
 ```
 
 :exclamation: Only use the `no-cache` option if you clear the cache afterwards, e.g. in a deployment process. Otherwise the changes will have no effect.


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR - thank you!

- [x] Pull request is based against develop branch
- [x] README.md reflects changes (if applicable)
- [x] New files contain a license header

### Proposed changes

When having environment variables set in your YAML files, but you don't have them set in your environment (like often happens locally), the `config:data:import` command will now interactively prompt you for those values;

![image](https://user-images.githubusercontent.com/431360/193418081-d61d13bf-50f5-430a-8ae8-f59b2745be7c.png)
