### PR TITLE
Add new --filepath option to allow control over the export path

### DIFF
--- a/Command/ExportCommand.php
+++ b/Command/ExportCommand.php
@@ -85,14 +85,14 @@ class ExportCommand extends AbstractCommand
             'filename',
             'f',
             InputOption::VALUE_OPTIONAL,
-            'File name into which should the export be written. Defaults to "config".'
+            'Filename into which the export should be written. Defaults to "config".'
         );
 
         $this->addOption(
             'filepath',
             'p',
             InputOption::VALUE_OPTIONAL,
-            'Path into which should the export be written. Defaults to "var/semaio/config_export/Ymd_His/".'
+            'Path into which the export should be written. Defaults to "var/semaio/config_export/Ymd_His/".'
         );
 
         $this->addOption(

--- a/Command/ExportCommand.php
+++ b/Command/ExportCommand.php
@@ -92,7 +92,7 @@ class ExportCommand extends AbstractCommand
             'filepath',
             'p',
             InputOption::VALUE_OPTIONAL,
-            'Path into which should the export be written. Defaults to "var/semaio/config_export/".'
+            'Path into which should the export be written. Defaults to "var/semaio/config_export/Ymd_His/".'
         );
 
         $this->addOption(

--- a/Command/ExportCommand.php
+++ b/Command/ExportCommand.php
@@ -85,7 +85,14 @@ class ExportCommand extends AbstractCommand
             'filename',
             'f',
             InputOption::VALUE_OPTIONAL,
-            'File name into which should the export be written. Defaults into var directory.'
+            'File name into which should the export be written. Defaults to "config".'
+        );
+
+        $this->addOption(
+            'filepath',
+            'p',
+            InputOption::VALUE_OPTIONAL,
+            'Path into which should the export be written. Defaults to "var/semaio/config_export/".'
         );
 
         $this->addOption(
@@ -139,10 +146,8 @@ class ExportCommand extends AbstractCommand
             throw new \InvalidArgumentException(ucfirst($format) . ' file writer could not be instantiated."');
         }
 
-        $filename = (string) $input->getOption('filename');
-        if ($filename != '') {
-            $writer->setBaseFilename($filename);
-        }
+        $writer->setBaseFilename((string) $input->getOption('filename'));
+        $writer->setBaseFilepath((string) $input->getOption('filepath'));
 
         $writer->setOutput($output);
         $writer->setIsHierarchical('y' === $input->getOption('hierarchical'));

--- a/Model/File/Writer/AbstractWriter.php
+++ b/Model/File/Writer/AbstractWriter.php
@@ -166,7 +166,7 @@ abstract class AbstractWriter implements WriterInterface
     public function setBaseFilepath($baseFilepath)
     {
         if ($baseFilepath === '') {
-            $baseFilepath = implode(DIRECTORY_SEPARATOR, ['var', 'semaio', 'config_export']);
+            $baseFilepath = implode(DIRECTORY_SEPARATOR, ['var', 'semaio', 'config_export', date('Ymd_His')]);
         }
         $this->baseFilepath = ltrim(rtrim($baseFilepath, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR);
     }

--- a/Model/File/Writer/AbstractWriter.php
+++ b/Model/File/Writer/AbstractWriter.php
@@ -168,7 +168,7 @@ abstract class AbstractWriter implements WriterInterface
         if ($baseFilepath === '') {
             $baseFilepath = implode(DIRECTORY_SEPARATOR, ['var', 'semaio', 'config_export', date('Ymd_His')]);
         }
-        $this->baseFilepath = ltrim(rtrim($baseFilepath, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR);
+        $this->baseFilepath = ltrim(rtrim($baseFilepath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR);
     }
 
     /**

--- a/Model/File/Writer/JsonWriter.php
+++ b/Model/File/Writer/JsonWriter.php
@@ -25,7 +25,7 @@ class JsonWriter extends AbstractWriter
         }
 
         // Write data to file
-        $tmpDirectory = $this->getFilesystem()->getDirectoryWrite(DirectoryList::VAR_DIR);
+        $tmpDirectory = $this->getFilesystem()->getDirectoryWrite(DirectoryList::ROOT);
         $tmpDirectory->writeFile($filename, $content);
         $this->getOutput()->writeln(sprintf(
             '<info>Wrote: %s settings to file %s</info>',

--- a/Model/File/Writer/WriterInterface.php
+++ b/Model/File/Writer/WriterInterface.php
@@ -35,10 +35,23 @@ interface WriterInterface
     public function getBaseFilename();
 
     /**
+     * @param string $baseFilepath
+     *
+     * @return void
+     */
+    public function setBaseFilepath($baseFilepath);
+
+    /**
+     * @return string
+     */
+    public function getBaseFilepath();
+
+    /**
      * @param OutputInterface $output
      *
      * @return void
      */
+
     public function setOutput(OutputInterface $output);
 
     /**

--- a/Model/File/Writer/YamlWriter.php
+++ b/Model/File/Writer/YamlWriter.php
@@ -31,7 +31,7 @@ class YamlWriter extends AbstractWriter
         }
 
         // Write data to file
-        $tmpDirectory = $this->getFilesystem()->getDirectoryWrite(DirectoryList::VAR_DIR);
+        $tmpDirectory = $this->getFilesystem()->getDirectoryWrite(DirectoryList::ROOT);
         $tmpDirectory->writeFile($filename, $content);
         $this->getOutput()->writeln(sprintf(
             '<info>Wrote: %s settings to file %s</info>',

--- a/docs/config-export.md
+++ b/docs/config-export.md
@@ -16,7 +16,8 @@ Usage:
 Options:
  --format (-m)           Format: yaml, json (default: "yaml")
  --hierarchical (-a)     Create a hierarchical or a flat structure (not all export format supports that). Enable with: y (default: "n")
- --filename (-f)         File name into which should the export be written. Defaults into var directory.
+ --filename (-f)         File name into which should the export be written. Defaults to "config".
+ --filepath (-p)         Path into which should the export be written. Defaults to "var/semaio/config_export/".
  --include (-i)          Path prefix, multiple values can be comma separated; exports only those paths
  --includeScope          Scope name, multiple values can be comma separated; exports only those scopes
  --exclude (-x)          Path prefix, multiple values can be comma separated; exports everything except ...

--- a/docs/config-export.md
+++ b/docs/config-export.md
@@ -16,8 +16,8 @@ Usage:
 Options:
  --format (-m)           Format: yaml, json (default: "yaml")
  --hierarchical (-a)     Create a hierarchical or a flat structure (not all export format supports that). Enable with: y (default: "n")
- --filename (-f)         File name into which should the export be written. Defaults to "config".
- --filepath (-p)         Path into which should the export be written. Defaults to "var/semaio/config_export/Ymd_His/".
+ --filename (-f)         Filename into which the export should be written. Defaults to "config".
+ --filepath (-p)         Path into which the export should be written. Defaults to "var/semaio/config_export/Ymd_His/".
  --include (-i)          Path prefix, multiple values can be comma separated; exports only those paths
  --includeScope          Scope name, multiple values can be comma separated; exports only those scopes
  --exclude (-x)          Path prefix, multiple values can be comma separated; exports everything except ...

--- a/docs/config-export.md
+++ b/docs/config-export.md
@@ -17,7 +17,7 @@ Options:
  --format (-m)           Format: yaml, json (default: "yaml")
  --hierarchical (-a)     Create a hierarchical or a flat structure (not all export format supports that). Enable with: y (default: "n")
  --filename (-f)         File name into which should the export be written. Defaults to "config".
- --filepath (-p)         Path into which should the export be written. Defaults to "var/semaio/config_export/".
+ --filepath (-p)         Path into which should the export be written. Defaults to "var/semaio/config_export/Ymd_His/".
  --include (-i)          Path prefix, multiple values can be comma separated; exports only those paths
  --includeScope          Scope name, multiple values can be comma separated; exports only those scopes
  --exclude (-x)          Path prefix, multiple values can be comma separated; exports everything except ...


### PR DESCRIPTION
- [X] Pull request is based against main branch
- [X] README.md reflects changes (if applicable)
- [X] New files contain a license header

### Issue

This PR fixes issue #60.

### Proposed changes

Based on the [response](https://github.com/semaio/Magento2-ConfigImportExport/issues/60#issuecomment-1280882487) from @therouv this PR implements a new `--filepath` option for the export command.

I believe these changes offer greater flexibility while also improving the default behaviour:

- `--filepath` Path into which the export should be written. Defaults to `var/semaio/config_export/Ymd_His/`.
- `--filename` Filename into which the export should be written. Defaults to `config`.

