### PR TITLE
Filename prefix when using filePerNameSpace

### DIFF
--- a/Model/File/Writer/AbstractWriter.php
+++ b/Model/File/Writer/AbstractWriter.php
@@ -252,7 +252,7 @@ abstract class AbstractWriter implements WriterInterface
 
         // Add namespace to file name if specified.
         if ($namespace !== null) {
-            $filename[] = $this->getBaseFilename() === '' ? 'config' . '_' . $namespace : $this->getBaseFilename() . '_' . $namespace;
+            $filename[] = $this->getBaseFilename() === '' ? $namespace : $this->getBaseFilename() . $namespace;
         } else {
             $filename[] = $this->getBaseFilename() === '' ? 'config' : $this->getBaseFilename();
         }

--- a/Model/File/Writer/AbstractWriter.php
+++ b/Model/File/Writer/AbstractWriter.php
@@ -246,17 +246,14 @@ abstract class AbstractWriter implements WriterInterface
      */
     private function getFilenameWithPath($namespace = null)
     {
-        $filename = [
-            $this->getBaseFilepath(),
-        ];
-
-        // Add namespace to file name if specified.
         if ($namespace !== null) {
-            $filename[] = $this->getBaseFilename() === '' ? $namespace : $this->getBaseFilename() . $namespace;
+            // Prefix namespace with filename when provided
+            $filename = $this->getBaseFilename() === '' ? $namespace : $this->getBaseFilename() . $namespace;
         } else {
-            $filename[] = $this->getBaseFilename() === '' ? 'config' : $this->getBaseFilename();
+            // Set default filename to 'config' when none provided
+            $filename = $this->getBaseFilename() === '' ? 'config' : $this->getBaseFilename();
         }
 
-        return implode('', $filename) . '.' . $this->getFileExtension();
+        return $this->getBaseFilepath() . $filename . '.' . $this->getFileExtension();
     }
 }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR - thank you!

- [x] Pull request is based against main branch
- [x] README.md reflects changes (if applicable)
- [x] New files contain a license header

### Issue

This PR fixes issue #67 

### Proposed changes

When using `filePerNameSpace`:

- if a filename is not provided then no prefix should be added to the output filename
- if a filename is provided then that filename should be used as the prefix without any additional underscore

With these proposed changes in place the user now has complete control over the output filename prefix. If they wish to have "config_" prefix then they can provide that as the filename argument. If they don't wish to have any prefix then they can just omit the filename argument. If they wish to have a prefix but without any underscore then they can do that too.

This PR also includes a minor refactor to simplify the `Model\File\Writer\AbstractWriter::getFilenameWithPath` method.