### PR TITLE
dynamic resolvers + theme code resolver

### DIFF
--- a/Exception/UnresolveableValueException.php
+++ b/Exception/UnresolveableValueException.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Copyright © semaio GmbH. All rights reserved.
+ * See LICENSE.md bundled with this module for license details.
+ */
+
+namespace Semaio\ConfigImportExport\Exception;
+
+class UnresolveableValueException extends \RuntimeException
+{
+}

--- a/Model/Processor/ImportProcessor.php
+++ b/Model/Processor/ImportProcessor.php
@@ -228,13 +228,15 @@ class ImportProcessor extends AbstractProcessor implements ImportProcessorInterf
 
                 try {
                     foreach ($this->resolvers as $resolver) {
-                        if ($resolver->supports($value)) {
-                            $resolver->setInput($this->getInput());
-                            $resolver->setOutput($this->getOutput());
-                            $resolver->setQuestionHelper($this->getQuestionHelper());
-
-                            $value = $resolver->resolve($value, $path);
+                        if (!$resolver->supports($value, $path)) {
+                            continue;
                         }
+
+                        $resolver->setInput($this->getInput());
+                        $resolver->setOutput($this->getOutput());
+                        $resolver->setQuestionHelper($this->getQuestionHelper());
+
+                        $value = $resolver->resolve($value, $path);
                     }
                 } catch (UnresolveableValueException $exception) {
                     $this->getOutput()->writeln(sprintf(

--- a/Model/Processor/ImportProcessor.php
+++ b/Model/Processor/ImportProcessor.php
@@ -7,14 +7,14 @@
 namespace Semaio\ConfigImportExport\Model\Processor;
 
 use Magento\Framework\App\Config\Storage\WriterInterface;
+use Semaio\ConfigImportExport\Exception\UnresolveableValueException;
 use Semaio\ConfigImportExport\Model\Converter\ScopeConverterInterface;
 use Semaio\ConfigImportExport\Model\File\FinderInterface;
 use Semaio\ConfigImportExport\Model\File\Reader\ReaderInterface;
-use Semaio\ConfigImportExport\Model\Resolver\EnvironmentVariableResolver;
+use Semaio\ConfigImportExport\Model\Resolver\ResolverInterface;
 use Semaio\ConfigImportExport\Model\Validator\ScopeValidatorInterface;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Question\Question;
 
 class ImportProcessor extends AbstractProcessor implements ImportProcessorInterface
 {
@@ -55,26 +55,26 @@ class ImportProcessor extends AbstractProcessor implements ImportProcessorInterf
     private $scopeConverter;
 
     /**
-     * @var EnvironmentVariableResolver
+     * @var ResolverInterface[]
      */
-    private $environmentVariableResolver;
+    private $resolvers;
 
     /**
-     * @param WriterInterface             $configWriter
-     * @param ScopeValidatorInterface     $scopeValidator
-     * @param ScopeConverterInterface     $scopeConverter
-     * @param EnvironmentVariableResolver $environmentVariableResolver
+     * @param WriterInterface         $configWriter
+     * @param ScopeValidatorInterface $scopeValidator
+     * @param ScopeConverterInterface $scopeConverter
+     * @param ResolverInterface[]     $resolvers
      */
     public function __construct(
         WriterInterface $configWriter,
         ScopeValidatorInterface $scopeValidator,
         ScopeConverterInterface $scopeConverter,
-        EnvironmentVariableResolver $environmentVariableResolver
+        array $resolvers = []
     ) {
         $this->configWriter = $configWriter;
         $this->scopeValidator = $scopeValidator;
         $this->scopeConverter = $scopeConverter;
-        $this->environmentVariableResolver = $environmentVariableResolver;
+        $this->resolvers = $resolvers;
     }
 
     /**
@@ -227,20 +227,24 @@ class ImportProcessor extends AbstractProcessor implements ImportProcessorInterf
                 }
 
                 try {
-                    $value = $this->environmentVariableResolver->resolveValue($value);
-                } catch (\UnexpectedValueException $e) {
-                    if ($this->getInput()->getOption('prompt-missing-env-vars') && $this->getInput()->isInteractive()) {
-                        $value = $this->getQuestionHelper()->ask($this->getInput(), $this->getOutput(), new Question($path . ': '));
-                    } else {
-                        $this->getOutput()->writeln(sprintf(
-                            '<error>%s (%s => %s)</error>',
-                            $e->getMessage(),
-                            $path,
-                            $value
-                        ));
+                    foreach ($this->resolvers as $resolver) {
+                        if ($resolver->supports($value)) {
+                            $resolver->setInput($this->getInput());
+                            $resolver->setOutput($this->getOutput());
+                            $resolver->setQuestionHelper($this->getQuestionHelper());
 
-                        continue;
+                            $value = $resolver->resolve($value, $path);
+                        }
                     }
+                } catch (UnresolveableValueException $exception) {
+                    $this->getOutput()->writeln(sprintf(
+                        '<error>%s (%s => %s)</error>',
+                        $exception->getMessage(),
+                        $path,
+                        $value
+                    ));
+
+                    continue;
                 }
 
                 $return[] = [

--- a/Model/Resolver/AbstractResolver.php
+++ b/Model/Resolver/AbstractResolver.php
@@ -1,6 +1,8 @@
 <?php
-
-declare(strict_types=1);
+/**
+ * Copyright © semaio GmbH. All rights reserved.
+ * See LICENSE.md bundled with this module for license details.
+ */
 
 namespace Semaio\ConfigImportExport\Model\Resolver;
 

--- a/Model/Resolver/AbstractResolver.php
+++ b/Model/Resolver/AbstractResolver.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Semaio\ConfigImportExport\Model\Resolver;
+
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class AbstractResolver implements ResolverInterface
+{
+    private InputInterface $input;
+    private OutputInterface $output;
+    private QuestionHelper $questionHelper;
+
+    public function setInput(InputInterface $input): void
+    {
+        $this->input = $input;
+    }
+
+    public function getInput(): InputInterface
+    {
+        return $this->input;
+    }
+
+    public function setOutput(OutputInterface $output): void
+    {
+        $this->output = $output;
+    }
+
+    public function getOutput(): OutputInterface
+    {
+        return $this->output;
+    }
+
+    public function setQuestionHelper(QuestionHelper $questionHelper): void
+    {
+        $this->questionHelper = $questionHelper;
+    }
+
+    public function getQuestionHelper(): QuestionHelper
+    {
+        return $this->questionHelper;
+    }
+}

--- a/Model/Resolver/AbstractResolver.php
+++ b/Model/Resolver/AbstractResolver.php
@@ -12,9 +12,20 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class AbstractResolver implements ResolverInterface
 {
-    private InputInterface $input;
-    private OutputInterface $output;
-    private QuestionHelper $questionHelper;
+    /**
+     * @var InputInterface
+     */
+    private $input;
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var QuestionHelper
+     */
+    private $questionHelper;
 
     public function setInput(InputInterface $input): void
     {

--- a/Model/Resolver/EnvironmentVariableResolver.php
+++ b/Model/Resolver/EnvironmentVariableResolver.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright © semaio GmbH. All rights reserved.
  * See LICENSE.md bundled with this module for license details.

--- a/Model/Resolver/EnvironmentVariableResolver.php
+++ b/Model/Resolver/EnvironmentVariableResolver.php
@@ -7,34 +7,58 @@
 
 namespace Semaio\ConfigImportExport\Model\Resolver;
 
-class EnvironmentVariableResolver
+use Semaio\ConfigImportExport\Exception\UnresolveableValueException;
+use Symfony\Component\Console\Question\Question;
+
+class EnvironmentVariableResolver extends AbstractResolver
 {
     /**
      * Resolve the config value if it's an environment variable reference.
      *
-     * @throws \UnexpectedValueException
-     *
      * @param string|null $value
+     * @param string|null $configPath
      *
      * @return string|null
+     *
+     * @throws UnresolveableValueException
      */
-    public function resolveValue($value)
+    public function resolve($value, $configPath = null)
     {
         if ($value === null) {
-            return $value;
+            return null;
         }
 
-        return preg_replace_callback(
-            '/\%env\((?!PHP_|HTTP_|SERVER_|SCRIPT_|QUERY_|DOCUMENT_)([A-Z0-9\_]{3,})\)\%/',
-            function ($matches) {
-                $resolvedValue = getenv($matches[1]);
-                if ($resolvedValue === false) {
-                    throw new \UnexpectedValueException(sprintf('Environment variable %s does not exist', $matches[1]));
-                }
+        try {
+            $value = (string) $value;
 
-                return $resolvedValue;
-            },
-            $value
-        );
+            $value = preg_replace_callback(
+                '/\%env\((?!PHP_|HTTP_|SERVER_|SCRIPT_|QUERY_|DOCUMENT_)([A-Z0-9\_]{3,})\)\%/',
+                function ($matches) {
+                    $resolvedValue = getenv($matches[1]);
+                    if ($resolvedValue === false) {
+                        throw new \UnexpectedValueException(sprintf('Environment variable %s does not exist', $matches[1]));
+                    }
+
+                    return $resolvedValue;
+                },
+                $value
+            );
+        } catch (\UnexpectedValueException $exception) {
+            if ($this->getInput()->getOption('prompt-missing-env-vars') && $this->getInput()->isInteractive()) {
+                $value = $this->getQuestionHelper()->ask($this->getInput(), $this->getOutput(), new Question($configPath . ': '));
+            } else {
+                throw new UnresolveableValueException($exception->getMessage());
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function supports($value): bool
+    {
+        return 0 === strncmp((string) $value, '%env', \strlen('%env'));
     }
 }

--- a/Model/Resolver/EnvironmentVariableResolver.php
+++ b/Model/Resolver/EnvironmentVariableResolver.php
@@ -56,7 +56,7 @@ class EnvironmentVariableResolver extends AbstractResolver
     /**
      * @inheritDoc
      */
-    public function supports($value): bool
+    public function supports($value, $configPath = null): bool
     {
         return 0 === strncmp((string) $value, '%env', \strlen('%env'));
     }

--- a/Model/Resolver/ResolverInterface.php
+++ b/Model/Resolver/ResolverInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright © semaio GmbH. All rights reserved.
  * See LICENSE.md bundled with this module for license details.

--- a/Model/Resolver/ResolverInterface.php
+++ b/Model/Resolver/ResolverInterface.php
@@ -24,8 +24,9 @@ interface ResolverInterface
 
     /**
      * @param string|null $value
+     * @param string|null $configPath
      */
-    public function supports($value): bool;
+    public function supports($value, $configPath = null): bool;
 
     public function setInput(InputInterface $input): void;
 

--- a/Model/Resolver/ResolverInterface.php
+++ b/Model/Resolver/ResolverInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Copyright © semaio GmbH. All rights reserved.
+ * See LICENSE.md bundled with this module for license details.
+ */
+
+namespace Semaio\ConfigImportExport\Model\Resolver;
+
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+interface ResolverInterface
+{
+    /**
+     * Resolve the config value.
+     *
+     * @param string|null $value
+     * @param string|null $configPath
+     *
+     * @return string|null
+     */
+    public function resolve($value, $configPath = null);
+
+    /**
+     * @param string|null $value
+     */
+    public function supports($value): bool;
+
+    public function setInput(InputInterface $input): void;
+
+    public function getInput(): InputInterface;
+
+    public function setOutput(OutputInterface $output): void;
+
+    public function getOutput(): OutputInterface;
+
+    public function setQuestionHelper(QuestionHelper $questionHelper): void;
+
+    public function getQuestionHelper(): QuestionHelper;
+}

--- a/Model/Resolver/ThemePathResolver.php
+++ b/Model/Resolver/ThemePathResolver.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright © semaio GmbH. All rights reserved.
  * See LICENSE.md bundled with this module for license details.

--- a/Model/Resolver/ThemePathResolver.php
+++ b/Model/Resolver/ThemePathResolver.php
@@ -12,7 +12,10 @@ use Semaio\ConfigImportExport\Exception\UnresolveableValueException;
 
 class ThemePathResolver extends AbstractResolver
 {
-    private ThemeProviderInterface $themeProvider;
+    /**
+     * @var ThemeProviderInterface
+     */
+    private $themeProvider;
 
     public function __construct(ThemeProviderInterface $themeProvider)
     {

--- a/Model/Resolver/ThemePathResolver.php
+++ b/Model/Resolver/ThemePathResolver.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Copyright © semaio GmbH. All rights reserved.
+ * See LICENSE.md bundled with this module for license details.
+ */
+
+namespace Semaio\ConfigImportExport\Model\Resolver;
+
+use Magento\Framework\View\Design\Theme\ThemeProviderInterface;
+use Magento\Framework\View\Design\ThemeInterface;
+use Semaio\ConfigImportExport\Exception\UnresolveableValueException;
+
+class ThemePathResolver extends AbstractResolver
+{
+    private ThemeProviderInterface $themeProvider;
+
+    public function __construct(ThemeProviderInterface $themeProvider)
+    {
+        $this->themeProvider = $themeProvider;
+    }
+
+    /**
+     * Resolve the config value if it's an theme code reference.
+     *
+     * @param string|null $value
+     * @param string|null $configPath
+     *
+     * @return string|null
+     *
+     * @throws UnresolveableValueException
+     */
+    public function resolve($value, $configPath = null)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = (string) $value;
+        if ($value === '%theme()%') {
+            throw new UnresolveableValueException('Please specify a valid theme name.');
+        }
+
+        $themeCode = preg_replace_callback(
+            '/\%theme\((?)([a-zA-Z0-9\/\_]{1,})\)\%/',
+            function ($matches) {
+                return $matches[1];
+            },
+            $value
+        );
+
+        $theme = $this->themeProvider->getThemeByFullPath($themeCode);
+        if ($theme instanceof ThemeInterface && $theme->getId()) {
+            return (string) $theme->getId();
+        }
+
+        throw new UnresolveableValueException(sprintf('Could not find theme with given value.', $themeCode));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function supports($value): bool
+    {
+        return 0 === strncmp((string) $value, '%theme', \strlen('%theme'));
+    }
+}

--- a/Model/Resolver/ThemePathResolver.php
+++ b/Model/Resolver/ThemePathResolver.php
@@ -59,7 +59,7 @@ class ThemePathResolver extends AbstractResolver
     /**
      * @inheritDoc
      */
-    public function supports($value): bool
+    public function supports($value, $configPath = null): bool
     {
         return 0 === strncmp((string) $value, '%theme', \strlen('%theme'));
     }

--- a/Test/Unit/Model/Processor/ImportProcessorTest.php
+++ b/Test/Unit/Model/Processor/ImportProcessorTest.php
@@ -13,7 +13,6 @@ use Semaio\ConfigImportExport\Model\Converter\ScopeConverterInterface;
 use Semaio\ConfigImportExport\Model\File\Finder;
 use Semaio\ConfigImportExport\Model\File\Reader\YamlReader;
 use Semaio\ConfigImportExport\Model\Processor\ImportProcessor;
-use Semaio\ConfigImportExport\Model\Resolver\EnvironmentVariableResolver;
 use Semaio\ConfigImportExport\Model\Validator\ScopeValidatorInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -40,11 +39,6 @@ class ImportProcessorTest extends TestCase
     private $scopeConverterMock;
 
     /**
-     * @var EnvironmentVariableResolver
-     */
-    private $environmentVariableResolver;
-
-    /**
      * Set up test class
      */
     protected function setUp(): void
@@ -55,7 +49,6 @@ class ImportProcessorTest extends TestCase
         $this->configWriterMock = $this->getMockBuilder(WriterInterface::class)->getMock();
         $this->scopeValidatorMock = $this->getMockBuilder(ScopeValidatorInterface::class)->getMock();
         $this->scopeConverterMock = $this->getMockBuilder(ScopeConverterInterface::class)->getMock();
-        $this->environmentVariableResolver = new EnvironmentVariableResolver();
     }
 
     /**
@@ -73,7 +66,7 @@ class ImportProcessorTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
 
-        $processor = new ImportProcessor($this->configWriterMock, $this->scopeValidatorMock, $this->scopeConverterMock, $this->environmentVariableResolver);
+        $processor = new ImportProcessor($this->configWriterMock, $this->scopeValidatorMock, $this->scopeConverterMock, []);
         $processor->setFinder($finderMock);
         $processor->process();
     }
@@ -104,7 +97,7 @@ class ImportProcessorTest extends TestCase
         $this->scopeValidatorMock->expects($this->once())->method('validate')->willReturn(false);
         $this->configWriterMock->expects($this->never())->method('save');
 
-        $processor = new ImportProcessor($this->configWriterMock, $this->scopeValidatorMock, $this->scopeConverterMock, $this->environmentVariableResolver);
+        $processor = new ImportProcessor($this->configWriterMock, $this->scopeValidatorMock, $this->scopeConverterMock, []);
         $processor->setFormat('yaml');
         $processor->setOutput($this->outputMock);
         $processor->setFinder($finderMock);
@@ -144,7 +137,7 @@ class ImportProcessorTest extends TestCase
         $this->configWriterMock->expects($this->once())->method('save');
         $this->configWriterMock->expects($this->once())->method('delete');
 
-        $processor = new ImportProcessor($this->configWriterMock, $this->scopeValidatorMock, $this->scopeConverterMock, $this->environmentVariableResolver);
+        $processor = new ImportProcessor($this->configWriterMock, $this->scopeValidatorMock, $this->scopeConverterMock, []);
         $processor->setOutput($this->outputMock);
         $processor->setFinder($finderMock);
         $processor->setReader($readerMock);

--- a/Test/Unit/Model/Resolver/EnvironmentVariableResolverTest.php
+++ b/Test/Unit/Model/Resolver/EnvironmentVariableResolverTest.php
@@ -50,6 +50,7 @@ class EnvironmentVariableResolverTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider resolveDataProvider
      */
     public function validate($value, $expectedResult): void

--- a/Test/Unit/Model/Resolver/ThemePathResolverTest.php
+++ b/Test/Unit/Model/Resolver/ThemePathResolverTest.php
@@ -14,11 +14,6 @@ use Semaio\ConfigImportExport\Model\Resolver\ThemePathResolver;
 
 class ThemePathResolverTest extends TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function testSuccessfulReplacement(): void
     {
         $theme = $this->createMock(ThemeInterface::class);
@@ -56,6 +51,20 @@ class ThemePathResolverTest extends TestCase
             ->method('getThemeByFullPath')
             ->with('frontend/Vendor/invalid')
             ->willReturn($theme);
+
+        $themePathResolver = new ThemePathResolver($themeProvider);
+        $themePathResolver->resolve('%theme(frontend/Vendor/invalid)%');
+    }
+
+    public function testItWillRaiseErrorIfThemeProviderReturnsNoThemeObject(): void
+    {
+        $this->expectException(UnresolveableValueException::class);
+
+        $themeProvider = $this->createMock(ThemeProviderInterface::class);
+        $themeProvider->expects($this->once())
+            ->method('getThemeByFullPath')
+            ->with('frontend/Vendor/invalid')
+            ->willReturn(null);
 
         $themePathResolver = new ThemePathResolver($themeProvider);
         $themePathResolver->resolve('%theme(frontend/Vendor/invalid)%');

--- a/Test/Unit/Model/Resolver/ThemePathResolverTest.php
+++ b/Test/Unit/Model/Resolver/ThemePathResolverTest.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * Copyright © semaio GmbH. All rights reserved.
+ * See LICENSE.md bundled with this module for license details.
+ */
 
 namespace Semaio\ConfigImportExport\Test\Unit\Model\Validator;
 

--- a/Test/Unit/Model/Resolver/ThemePathResolverTest.php
+++ b/Test/Unit/Model/Resolver/ThemePathResolverTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Semaio\ConfigImportExport\Test\Unit\Model\Validator;
+
+use Magento\Framework\View\Design\Theme\ThemeProviderInterface;
+use Magento\Framework\View\Design\ThemeInterface;
+use PHPUnit\Framework\TestCase;
+use Semaio\ConfigImportExport\Exception\UnresolveableValueException;
+use Semaio\ConfigImportExport\Model\Resolver\ThemePathResolver;
+
+class ThemePathResolverTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testSuccessfulReplacement(): void
+    {
+        $theme = $this->createMock(ThemeInterface::class);
+        $theme->expects($this->any())->method('getId')->willReturn(13);
+
+        $themeProvider = $this->createMock(ThemeProviderInterface::class);
+        $themeProvider->expects($this->once())
+            ->method('getThemeByFullPath')
+            ->with('frontend/Vendor/theme')
+            ->willReturn($theme);
+
+        $themePathResolver = new ThemePathResolver($themeProvider);
+        $this->assertEquals('13', $themePathResolver->resolve('%theme(frontend/Vendor/theme)%'));
+    }
+
+    public function testItWillRaiseErrorIfJustWrapperIsGiven(): void
+    {
+        $this->expectException(UnresolveableValueException::class);
+
+        $themeProvider = $this->createMock(ThemeProviderInterface::class);
+
+        $themePathResolver = new ThemePathResolver($themeProvider);
+        $this->assertEquals('13', $themePathResolver->resolve('%theme()%'));
+    }
+
+    public function testItWillRaiseErrorIfThemeWasNotFound(): void
+    {
+        $this->expectException(UnresolveableValueException::class);
+
+        $theme = $this->createMock(ThemeInterface::class);
+        $theme->expects($this->any())->method('getId')->willReturn(null);
+
+        $themeProvider = $this->createMock(ThemeProviderInterface::class);
+        $themeProvider->expects($this->once())
+            ->method('getThemeByFullPath')
+            ->with('frontend/Vendor/invalid')
+            ->willReturn($theme);
+
+        $themePathResolver = new ThemePathResolver($themeProvider);
+        $themePathResolver->resolve('%theme(frontend/Vendor/invalid)%');
+    }
+}

--- a/docs/config-import.md
+++ b/docs/config-import.md
@@ -58,6 +58,20 @@ php bin/magento config:data:import config/store dev/therouv
 
 The files in the `base` folder will always be imported (if they exist), regardless of which environment parameter has been passed. If the base and environment configurations have the same configuration field set, then the environment value for that configuration will overwrite the base configuration.
 
+### Theme code substitution
+
+If you do not want to store hard-coded theme IDs in your files, but rather the theme code, you can use placeholders for theme codes in the configuration files. This is done with the notation `%theme(path)%` (make sure to put quotes around it).
+
+For example, this might be the content of your config file:
+
+```
+design/theme/theme_id:
+  default:
+    0: '%theme(frontend/Vendor/theme)%'
+```
+
+Always use theme path that is defined as component name in the `registration.php` file of your theme (including the area (e.g. `frontend`) in front), e.g. `frontend/Vendor/theme` and never `Vendor/theme`.
+
 ### Environment Variables substitution
 
 If you do not want to store your secrets in version control, you can use placeholders for environment variables in the configuration files. This is done with the notation `%env(ENV_VAR_NAME)%` (make sure to put quotes around it).

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -12,6 +12,15 @@
     <preference for="Semaio\ConfigImportExport\Model\File\FinderInterface" type="Semaio\ConfigImportExport\Model\File\Finder"/>
     <preference for="Semaio\ConfigImportExport\Model\Converter\ScopeConverterInterface" type="Semaio\ConfigImportExport\Model\Converter\ScopeConverter" />
 
+    <type name="Semaio\ConfigImportExport\Model\Processor\ImportProcessor">
+        <arguments>
+            <argument name="resolvers" xsi:type="array">
+                <item name="environmentVariableResolver" xsi:type="object">Semaio\ConfigImportExport\Model\Resolver\EnvironmentVariableResolver</item>
+                <item name="themePathResolver" xsi:type="object">Semaio\ConfigImportExport\Model\Resolver\ThemePathResolver</item>
+            </argument>
+        </arguments>
+    </type>
+
     <type name="Magento\Framework\Console\CommandListInterface">
         <arguments>
             <argument name="commands" xsi:type="array">


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR - thank you!

- [x] Pull request is based against main branch
- [X] README.md reflects changes (if applicable)
- [x] New files contain a license header

# Changes

## Dynamic Resolvers

Previously, the environment variable resolver was the only available resolver. This was not very flexible if one might want to add additional resolvers (either to this module or project-specific resolvers).

The `ImportProcessor` now accepts an array with all resolvers that have been defined in `di.xml`.

Each resolver must implement a `supports` method which checks whether a value or a config path matches certain criteria. If yes, the resolver will be called.

If a value can not be resolved and should be skipped in the process, a `UnresolveableValueException` exception must be thrown by the resolver.

## Environment Variable Resolver

The prompting for missing environment variables has been moved to the resolver and is no longer part of the `ImportProcessor`.

## Theme Code Resolver (NEW)

When assigning a theme to a website/store, Magento internally saves the ID of the selected theme in the config database table (path `design/theme/theme_id`). Theme IDs might change but also hard-coding them in a config file is not recommended.

Previously, there was no way to configure this value using this module. Now, you can use a specific syntax for theme codes in the configuration files. This is done with the syntax `%theme(path)%` (after discussing with some people, I opted for a similar syntax like we already use for environment variables).

For example, this might be the content of your config file:

```yaml
design/theme/theme_id:
  default:
    0: '%theme(frontend/Vendor/theme)%'
```

The placeholder requires the theme path that is defined as component name in the `registration.php` file of a Magento theme, e.g. `frontend/Vendor/theme` (never use just `Vendor/theme`!).

The module will check if this theme is available in Magento. If yes, the module will write the ID of the theme to the `core_config_data` table. If no theme with that path can be found, an `UnresolveableValueException` exception will be thrown.