### PR TITLE
allow to run command with empty import directories

### DIFF
--- a/Command/ImportCommand.php
+++ b/Command/ImportCommand.php
@@ -127,6 +127,13 @@ class ImportCommand extends AbstractCommand
             true
         );
 
+        $this->addOption(
+            'allow-empty-directories',
+            'e',
+            InputOption::VALUE_NONE,
+            'Allow empty directories during import.'
+        );
+
         parent::configure();
     }
 

--- a/Model/Processor/ImportProcessor.php
+++ b/Model/Processor/ImportProcessor.php
@@ -85,8 +85,11 @@ class ImportProcessor extends AbstractProcessor implements ImportProcessorInterf
     public function process()
     {
         $files = $this->finder->find();
-        if (0 === count($files)) {
+        if (0 === count($files) && false === $this->getInput()->getOption('allow-empty-directories')) {
             throw new \InvalidArgumentException('No files found for format: *.' . $this->getFormat());
+        } else {
+            $this->getOutput()->writeln('No files found for format: *.' . $this->getFormat());
+            $this->getOutput()->writeln('Maybe this is expected behaviour, because you passed the --allow-empty-directories option.');
         }
 
         foreach ($files as $file) {

--- a/docs/config-import.md
+++ b/docs/config-import.md
@@ -19,6 +19,7 @@ $ php bin/magento config:data:import --help
   --no-cache                       Do not clear cache after config data import.
   --recursive (-r)                 Recursively go over subdirectories and import configs.
   --prompt-missing-env-vars (-p)   Prompt in interactive mode when environment variables are found but not configured (Default: true)
+  --allow-empty-directories (-e)   Do not throw error if import directories are empty.
 ```
 
 :exclamation: Only use the `no-cache` option if you clear the cache afterwards, e.g. in a deployment process. Otherwise the changes will have no effect.


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR - thank you!

- [x] Pull request is based against main branch
- [x] README.md reflects changes (if applicable)
- [x] New files contain a license header

### Issue

This PR fixes issue #70.

### Proposed changes

Allow to run import even if directories are empty. Without the option the import still throws the error like it is now.
