### PR TITLE
update regex to catch all theme names

### DIFF
--- a/Model/Resolver/ThemePathResolver.php
+++ b/Model/Resolver/ThemePathResolver.php
@@ -44,7 +44,7 @@ class ThemePathResolver extends AbstractResolver
         }
 
         $themeCode = preg_replace_callback(
-            '/\%theme\((?)([a-zA-Z0-9\/\_]{1,})\)\%/',
+            '/\%theme\(([^)]+)\)\%/',
             function ($matches) {
                 return $matches[1];
             },


### PR DESCRIPTION
- [X] Pull request is based against main branch
- [X] README.md reflects changes (if applicable)
- [X] New files contain a license header

### Issue

The given regex: `/\%theme\((?)([a-zA-Z0-9\/\_]{1,})\)\%/` does not catch `-` in the theme name.
For example: `%theme(frontend/Vendor/my-theme)%`

### Proposed changes

The new regex: `/\%theme\(([^)]+)\)\%/` caches everything between ( and ):

<img width="790" alt="image" src="https://github.com/semaio/Magento2-ConfigImportExport/assets/7961978/0d18f72a-69c4-4263-a718-af9cdf83dedf">
by regex101.com
