### PR TITLE
Allow to KEEP configs unchanged on the environment

### DIFF
--- a/Model/Processor/ImportProcessor.php
+++ b/Model/Processor/ImportProcessor.php
@@ -103,11 +103,13 @@ class ImportProcessor extends AbstractProcessor implements ImportProcessorInterf
                     if ($value === self::DELETE_CONFIG_FLAG) {
                         $this->configWriter->delete($configPath, $scopeType, $scopeId);
                         $this->getOutput()->writeln(sprintf('<comment>[%s] [%s] %s => %s</comment>', $scopeType, $scopeId, $configPath, 'DELETED'));
+
                         continue;
                     }
 
                     if ($value === self::KEEP_CONFIG_FLAG) {
                         $this->getOutput()->writeln(sprintf('<comment>[%s] [%s] %s => %s</comment>', $scopeType, $scopeId, $configPath, 'KEPT'));
+
                         continue;
                     }
 
@@ -120,6 +122,7 @@ class ImportProcessor extends AbstractProcessor implements ImportProcessorInterf
 
     /**
      * @param array $files
+     *
      * @return array
      */
     private function collectConfigs(array $files): array

--- a/Test/Unit/Model/Processor/ImportProcessorTest.php
+++ b/Test/Unit/Model/Processor/ImportProcessorTest.php
@@ -14,6 +14,7 @@ use Semaio\ConfigImportExport\Model\File\Finder;
 use Semaio\ConfigImportExport\Model\File\Reader\YamlReader;
 use Semaio\ConfigImportExport\Model\Processor\ImportProcessor;
 use Semaio\ConfigImportExport\Model\Validator\ScopeValidatorInterface;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ImportProcessorTest extends TestCase
@@ -67,6 +68,9 @@ class ImportProcessorTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         $processor = new ImportProcessor($this->configWriterMock, $this->scopeValidatorMock, $this->scopeConverterMock, []);
+        $inputMock = $this->getMockBuilder(InputInterface::class)->getMock();
+        $inputMock->method('getOption')->with('allow-empty-directories')->willReturn(false);
+        $processor->setInput($inputMock);
         $processor->setFinder($finderMock);
         $processor->process();
     }
@@ -126,6 +130,16 @@ class ImportProcessorTest extends TestCase
                     0 => '!!DELETE',
                 ],
             ],
+            'test/config/custom_field_to_be_keeped' => [
+                'default' => [
+                    0 => 'VALUE_THAT_SHOULD_NOT_BE_PROCESSED',
+                ],
+            ],
+            'test/config/custom_field_to_be_keeped' => [
+                'default' => [
+                    0 => '!!KEEP',
+                ],
+            ],
         ];
 
         $readerMock = $this->getMockBuilder(YamlReader::class)
@@ -133,7 +147,7 @@ class ImportProcessorTest extends TestCase
             ->getMock();
         $readerMock->expects($this->once())->method('parse')->willReturn($parseResult);
 
-        $this->scopeValidatorMock->expects($this->exactly(2))->method('validate')->willReturn(true);
+        $this->scopeValidatorMock->expects($this->exactly(3))->method('validate')->willReturn(true);
         $this->configWriterMock->expects($this->once())->method('save');
         $this->configWriterMock->expects($this->once())->method('delete');
 

--- a/docs/config-import.md
+++ b/docs/config-import.md
@@ -97,6 +97,21 @@ vendorx/general/api_key:
     0: "!!DELETE"
 ```
 
+### Keep Config
+
+If you want to make sure that config value will not be affected by config importer - use `!!KEEP` magic-ish string.  
+
+#### When would it be helpful?
+When you have a bunch of same configs in different environments, but there one environment ( `X` env ) where you want to keep it as is, but not dispose the exact value of `X` env in config files.  
+Security sensitive data are good examples of such cases - you want them to be kept only in env DB, and definitely not in your GIT repo. 
+
+```yaml
+vendorx/general/api_key:
+  default:
+    0: "!!KEEP"
+```
+
+
 ### Recursive folder setup
 
 If you choose to store your configuration files in subdirectories, e.g. per vendor, the recommended folder setup should look like this:


### PR DESCRIPTION
Allow to KEEP configs unchanged on the environment => Base config will not override configs that are already set on environment, in case we use `"!!KEEP"` directive.  

This is needed in stations when you have couple test environments, that share same test credentials. By utilizing this feature you could keep test credentials be stored under `base` scope, but on `production` scope you just add `"!!KEEP"`  value to not override production configurations.  
This would add a significant possibility to decrease configs duplications.

### Example

#### Setup before changes

```
dev1:
- config/abc/key: "qwerty"

dev2:
- config/abc/key: "qwerty"

staging1:
- config/abc/key: "qwerty"

staging2:
- config/abc/key: "qwerty"

test_env1:
- config/abc/key: "qwerty"

test_env2:
- config/abc/key: "qwerty"
```
 
#### Setup after changes

```
base:
- config/abc/key: "qwerty"

production:
- config/abc/key: "!!KEEP"
```