### PR TITLE
Enhancement/added import command lock flag

### DIFF
--- a/Command/ImportCommand.php
+++ b/Command/ImportCommand.php
@@ -134,6 +134,13 @@ class ImportCommand extends AbstractCommand
             'Allow empty directories during import.'
         );
 
+        $this->addOption(
+            'lock-config',
+            'c',
+            InputOption::VALUE_NONE,
+            'Additionally lock imported values in app/etc/config.php (read-only in Admin).'
+        );
+
         parent::configure();
     }
 

--- a/Model/Processor/ImportProcessor.php
+++ b/Model/Processor/ImportProcessor.php
@@ -6,7 +6,13 @@
 
 namespace Semaio\ConfigImportExport\Model\Processor;
 
+use Magento\Config\App\Config\Type\System;
+use Magento\Deploy\Model\DeploymentConfig\Hash;
+use Magento\Framework\App\Config\ConfigPathResolver;
 use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\App\DeploymentConfig\Writer as DeploymentConfigWriter;
+use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\Stdlib\ArrayManager;
 use Semaio\ConfigImportExport\Exception\UnresolveableValueException;
 use Semaio\ConfigImportExport\Model\Converter\ScopeConverterInterface;
 use Semaio\ConfigImportExport\Model\File\FinderInterface;
@@ -62,20 +68,52 @@ class ImportProcessor extends AbstractProcessor implements ImportProcessorInterf
     private $resolvers;
 
     /**
+     * @var DeploymentConfigWriter
+     */
+    private $deploymentConfigWriter;
+
+    /**
+     * @var ConfigPathResolver
+     */
+    private $configPathResolver;
+
+    /**
+     * @var ArrayManager
+     */
+    private $arrayManager;
+
+    /**
+     * @var Hash
+     */
+    private $hash;
+
+    /**
      * @param WriterInterface         $configWriter
      * @param ScopeValidatorInterface $scopeValidator
      * @param ScopeConverterInterface $scopeConverter
+     * @param DeploymentConfigWriter  $deploymentConfigWriter
+     * @param ConfigPathResolver      $configPathResolver
+     * @param ArrayManager            $arrayManager
+     * @param Hash                    $hash
      * @param ResolverInterface[]     $resolvers
      */
     public function __construct(
         WriterInterface $configWriter,
         ScopeValidatorInterface $scopeValidator,
         ScopeConverterInterface $scopeConverter,
+        DeploymentConfigWriter $deploymentConfigWriter,
+        ConfigPathResolver $configPathResolver,
+        ArrayManager $arrayManager,
+        Hash $hash,
         array $resolvers = []
     ) {
         $this->configWriter = $configWriter;
         $this->scopeValidator = $scopeValidator;
         $this->scopeConverter = $scopeConverter;
+        $this->deploymentConfigWriter = $deploymentConfigWriter;
+        $this->configPathResolver = $configPathResolver;
+        $this->arrayManager = $arrayManager;
+        $this->hash = $hash;
         $this->resolvers = $resolvers;
     }
 
@@ -103,12 +141,21 @@ class ImportProcessor extends AbstractProcessor implements ImportProcessorInterf
             return;
         }
 
+        $shouldLock = $this->shouldLockConfig();
+        $lockData = [];
+
         foreach ($configurationValues as $configPath => $configValue) {
             foreach ($configValue as $scopeType => $scopeValue) {
                 foreach ($scopeValue as $scopeId => $value) {
                     if ($value === self::DELETE_CONFIG_FLAG) {
                         $this->configWriter->delete($configPath, $scopeType, $scopeId);
                         $this->getOutput()->writeln(sprintf('<comment>[%s] [%s] %s => %s</comment>', $scopeType, $scopeId, $configPath, 'DELETED'));
+
+                        if ($shouldLock) {
+                            $this->getOutput()->writeln(
+                                sprintf('<info>  Note: If this path is locked in app/etc/config.php, remove it manually.</info>')
+                            );
+                        }
 
                         continue;
                     }
@@ -121,9 +168,64 @@ class ImportProcessor extends AbstractProcessor implements ImportProcessorInterf
 
                     $this->configWriter->save($configPath, $value, $scopeType, $scopeId);
                     $this->getOutput()->writeln(sprintf('<comment>[%s] [%s] %s => %s</comment>', $scopeType, $scopeId, $configPath, $value));
+
+                    if ($shouldLock) {
+                        $lockData[] = [
+                            'path'     => $configPath,
+                            'value'    => $value,
+                            'scope'    => $scopeType,
+                            'scope_id' => $scopeId,
+                        ];
+                    }
                 }
             }
         }
+
+        if ($shouldLock && !empty($lockData)) {
+            $this->writeToConfigPhp($lockData);
+        }
+    }
+
+    /**
+     * Check if --lock-config option is enabled.
+     */
+    private function shouldLockConfig(): bool
+    {
+        $input = $this->getInput();
+        return $input && $input->hasOption('lock-config') && $input->getOption('lock-config');
+    }
+
+    /**
+     * Batch-write collected values to app/etc/config.php.
+     */
+    private function writeToConfigPhp(array $lockData): void
+    {
+        $this->getOutput()->writeln(' ');
+        $this->getOutput()->writeln('<info>Locking values in app/etc/config.php...</info>');
+
+        $configArray = [];
+        foreach ($lockData as $item) {
+            $resolvedPath = $this->configPathResolver->resolve(
+                $item['path'],
+                $item['scope'],
+                $item['scope_id'],
+                System::CONFIG_TYPE
+            );
+            $configArray = $this->arrayManager->set($resolvedPath, $configArray, $item['value']);
+        }
+
+        $this->deploymentConfigWriter->saveConfig(
+            [ConfigFilePool::APP_CONFIG => $configArray],
+            false
+        );
+
+        $this->hash->regenerate(System::CONFIG_TYPE);
+
+        $this->getOutput()->writeln(sprintf(
+            '<info>%d %s locked in app/etc/config.php.</info>',
+            count($lockData),
+            count($lockData) === 1 ? 'value' : 'values'
+        ));
     }
 
     /**

--- a/Model/Processor/ImportProcessor.php
+++ b/Model/Processor/ImportProcessor.php
@@ -7,7 +7,6 @@
 namespace Semaio\ConfigImportExport\Model\Processor;
 
 use Magento\Config\App\Config\Type\System;
-use Magento\Deploy\Model\DeploymentConfig\Hash;
 use Magento\Framework\App\Config\ConfigPathResolver;
 use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\Framework\App\DeploymentConfig\Writer as DeploymentConfigWriter;
@@ -83,18 +82,12 @@ class ImportProcessor extends AbstractProcessor implements ImportProcessorInterf
     private $arrayManager;
 
     /**
-     * @var Hash
-     */
-    private $hash;
-
-    /**
      * @param WriterInterface         $configWriter
      * @param ScopeValidatorInterface $scopeValidator
      * @param ScopeConverterInterface $scopeConverter
      * @param DeploymentConfigWriter  $deploymentConfigWriter
      * @param ConfigPathResolver      $configPathResolver
      * @param ArrayManager            $arrayManager
-     * @param Hash                    $hash
      * @param ResolverInterface[]     $resolvers
      */
     public function __construct(
@@ -104,7 +97,6 @@ class ImportProcessor extends AbstractProcessor implements ImportProcessorInterf
         DeploymentConfigWriter $deploymentConfigWriter,
         ConfigPathResolver $configPathResolver,
         ArrayManager $arrayManager,
-        Hash $hash,
         array $resolvers = []
     ) {
         $this->configWriter = $configWriter;
@@ -113,7 +105,6 @@ class ImportProcessor extends AbstractProcessor implements ImportProcessorInterf
         $this->deploymentConfigWriter = $deploymentConfigWriter;
         $this->configPathResolver = $configPathResolver;
         $this->arrayManager = $arrayManager;
-        $this->hash = $hash;
         $this->resolvers = $resolvers;
     }
 
@@ -218,8 +209,6 @@ class ImportProcessor extends AbstractProcessor implements ImportProcessorInterf
             [ConfigFilePool::APP_CONFIG => $configArray],
             false
         );
-
-        $this->hash->regenerate(System::CONFIG_TYPE);
 
         $this->getOutput()->writeln(sprintf(
             '<info>%d %s locked in app/etc/config.php.</info>',

--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ See [docs/file-formats.md](docs/file-formats.md) for more information and exampl
 
 See [docs/config-import.md](docs/config-import.md) for more information.
 
+#### Lock config values
+
+You can lock imported values in `app/etc/config.php` to make them read-only in the Admin panel:
+
+```bash
+php bin/magento config:data:import config/store production --lock-config
+```
+
+This writes values to both the database and `config.php`. Locked values appear greyed out in Admin > Stores > Configuration. See the [import docs](docs/config-import.md#lock-config) for details.
+
 
 ### Export config data
 

--- a/docs/config-import.md
+++ b/docs/config-import.md
@@ -20,6 +20,7 @@ $ php bin/magento config:data:import --help
   --recursive (-r)                 Recursively go over subdirectories and import configs.
   --prompt-missing-env-vars (-p)   Prompt in interactive mode when environment variables are found but not configured (Default: true)
   --allow-empty-directories (-e)   Do not throw error if import directories are empty.
+  --lock-config (-c)               Additionally lock imported values in app/etc/config.php (read-only in Admin).
 ```
 
 :exclamation: Only use the `no-cache` option if you clear the cache afterwards, e.g. in a deployment process. Otherwise the changes will have no effect.
@@ -122,6 +123,20 @@ vendorx/general/api_key:
 ```
 
 This is helpful when you've got the same settings across different environments but want to keep one environment ( `X` env) unchanged without showing the exact value in the config file. It's a common scenario, especially when dealing with sensitive data. You really should only keep that kind of info in the environment’s database, not in your GIT repo.
+
+### Lock Config
+
+By default, imported values are written to the database (`core_config_data`) and remain editable in the Admin panel. If you want to additionally lock the values so they become **read-only in Admin**, use the `--lock-config` option:
+
+```bash
+php bin/magento config:data:import config/store production --lock-config
+```
+
+This writes the imported values to both the database **and** `app/etc/config.php`. Values stored in `config.php` take precedence over database values and appear greyed out (non-editable) in Admin > Stores > Configuration.
+
+:exclamation: When using `--lock-config` together with `!!DELETE`, the value is removed from the database but **not** from `config.php`. If the value was previously locked, you need to remove it from `app/etc/config.php` manually.
+
+:exclamation: The `--lock-config` option writes to the filesystem. Make sure `app/etc/config.php` is writable by the PHP process.
 
 ### Recursive folder setup
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR - thank you!

- [x] Pull request is based against main branch
- [x] README.md reflects changes (if applicable)
- [x] New files contain a license header

### Proposed changes

  Added --lock-config (-c) option to the config:data:import CLI command. When used, imported configuration values are written to both the database (core_config_data) and app/etc/config.php, making them        
  read-only (greyed out) in Admin > Stores > Configuration.                                                                                                                                                      
                                                                                                                                                                                                                 
  Changed files                                                                                                                                                                                                  
                                                                                                                                                                                                                 
  Command/ImportCommand.php
  - Added --lock-config (-c) option definition in configure()

  Model/Processor/ImportProcessor.php
  - Added 3 constructor dependencies: DeploymentConfig\Writer, ConfigPathResolver, ArrayManager
  - During the import loop, values are collected into a $lockData array when --lock-config is active
  - After the loop, all collected values are batch-written to app/etc/config.php in a single saveConfig() call (merge mode)
  - !!DELETE entries print a notice that locked values in config.php must be removed manually
  - !!KEEP entries are unaffected (skipped as before)

  README.md / docs/config-import.md
  - Documented the new --lock-config option with usage examples and caveats

  Usage

  #### Standard import (unchanged)
  php bin/magento config:data:import config/store production

  #### Import + lock in config.php
  php bin/magento config:data:import config/store production --lock-config

... 

This PR adds an additional --lock-config option to the import command. Issue #24 